### PR TITLE
chore: update rocksdb dependency to 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,30 +77,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
-dependencies = [
- "bitflags",
- "cexpr",
- "cfg-if 0.1.10",
- "clang-sys",
- "clap",
- "env_logger",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "proc-macro2 1.0.24",
- "quote 1.0.7",
- "regex",
- "rustc-hash",
- "shlex",
- "which",
-]
-
-[[package]]
 name = "bit-vec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,15 +145,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
 dependencies = [
  "jobserver",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -261,6 +228,7 @@ name = "ckb-indexer"
 version = "0.2.0"
 dependencies = [
  "ckb-jsonrpc-types",
+ "ckb-rocksdb",
  "ckb-types",
  "clap",
  "env_logger",
@@ -273,7 +241,6 @@ dependencies = [
  "jsonrpc-server-utils",
  "log",
  "rand 0.6.5",
- "rocksdb",
  "serde",
  "serde_json",
  "tempfile",
@@ -290,6 +257,17 @@ dependencies = [
  "jsonrpc-core",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "ckb-librocksdb-sys"
+version = "6.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a78d3b9b5fd3b4990ddd2083f6a6d4389b6c8e603a4f2896914165113beed2d"
+dependencies = [
+ "cc",
+ "glob",
+ "libc",
 ]
 
 [[package]]
@@ -333,6 +311,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-rocksdb"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a645f6745c3519bbcbeed80486e59cb3f74d2ac08a1d9621c399b892508aca6e"
+dependencies = [
+ "ckb-librocksdb-sys",
+ "libc",
+ "tempfile",
+]
+
+[[package]]
 name = "ckb-types"
 version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,17 +339,6 @@ dependencies = [
  "molecule",
  "numext-fixed-uint",
  "once_cell",
-]
-
-[[package]]
-name = "clang-sys"
-version = "0.29.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -606,9 +584,9 @@ checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 
 [[package]]
 name = "globset"
@@ -904,38 +882,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
-
-[[package]]
-name = "libloading"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
-dependencies = [
- "cc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "librocksdb-sys"
-version = "6.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b56f651c204634b936be2f92dbb42c36867e00ff7fe2405591f3b9fa66f09"
-dependencies = [
- "bindgen",
- "cc",
- "glob",
- "libc",
-]
 
 [[package]]
 name = "lock_api"
@@ -1081,16 +1031,6 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -1245,12 +1185,6 @@ dependencies = [
  "smallvec 1.4.2",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -1530,26 +1464,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rocksdb"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12069b106981c6103d3eab7dd1c86751482d0779a520b7c14954c8b586c1e643"
-dependencies = [
- "libc",
- "librocksdb-sys",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -1650,12 +1568,6 @@ dependencies = [
  "ryu",
  "serde",
 ]
-
-[[package]]
-name = "shlex"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "slab"
@@ -2109,15 +2021,6 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "which"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rocksdb = "0.13"
+rocksdb = { package = "ckb-rocksdb", version = "=0.15.1" }
 ckb-types = "0.40.0"
 ckb-jsonrpc-types = "0.40.0"
 jsonrpc-core = "14.0"

--- a/src/service.rs
+++ b/src/service.rs
@@ -13,7 +13,7 @@ use jsonrpc_http_server::{Server, ServerBuilder};
 use jsonrpc_server_utils::cors::AccessControlAllowOrigin;
 use jsonrpc_server_utils::hosts::DomainsValidation;
 use log::{error, info, trace};
-use rocksdb::{Direction, IteratorMode};
+use rocksdb::{prelude::*, Direction, IteratorMode};
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::net::ToSocketAddrs;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -23,7 +23,7 @@ pub trait Store {
         &self,
         from_key: K,
         direction: IteratorDirection,
-    ) -> Result<Box<dyn Iterator<Item = IteratorItem>>, Error>;
+    ) -> Result<Box<dyn Iterator<Item = IteratorItem> + '_>, Error>;
     fn batch(&self) -> Result<Self::Batch, Error>;
 }
 

--- a/src/store/rocksdb.rs
+++ b/src/store/rocksdb.rs
@@ -1,5 +1,5 @@
 use super::{Batch, Error, IteratorDirection, IteratorItem, Store};
-use rocksdb::{Direction, IteratorMode, WriteBatch, DB};
+use rocksdb::{prelude::*, Direction, IteratorMode, WriteBatch, DB};
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -33,7 +33,7 @@ impl Store for RocksdbStore {
         &self,
         from_key: K,
         mode: IteratorDirection,
-    ) -> Result<Box<dyn Iterator<Item = IteratorItem>>, Error> {
+    ) -> Result<Box<dyn Iterator<Item = IteratorItem> + '_>, Error> {
         let mode = IteratorMode::From(
             from_key.as_ref(),
             match mode {
@@ -69,7 +69,7 @@ impl Batch for RocksdbBatch {
     }
 
     fn commit(self) -> Result<(), Error> {
-        self.db.write(self.wb)?;
+        self.db.write(&self.wb)?;
         Ok(())
     }
 }


### PR DESCRIPTION
Q: Why update rocksdb dependency?
A: To stick with the rocksdb version used in [ckb](https://github.com/nervosnetwork/ckb/blob/65008558a2b71136cc42f84a97ec9b3e97c85a19/db/Cargo.toml#L16)

Tested compatibility with [ckb-indexer 0.2.0](https://github.com/nervosnetwork/ckb-indexer/releases/tag/v0.2.0).

Test method:
1. start **old** version ckb-indexer sync testnet to 330K blocks, then start **new** version ckb-indexer continue sync to 660K blocks.
2. start **new** version ckb-indexer sync testnet to 330K blocks, then start **old** version ckb-indexer continue sync to 660K blocks.