### PR TITLE
feat: add long fork detection

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -72,7 +72,9 @@ impl Service {
     }
 
     pub async fn poll(&self, rpc_client: gen_client::Client) {
-        let indexer = Indexer::new(self.store.clone(), 100, 1000);
+        // assume that long fork will not happen >= 100 blocks.
+        let keep_num = 100;
+        let indexer = Indexer::new(self.store.clone(), keep_num, 1000);
         // 0.37.0 and above supports hex format
         let use_hex_format = loop {
             match rpc_client.local_node_info().await {
@@ -98,8 +100,37 @@ impl Service {
                             info!("append {}, {}", block.number(), block.hash());
                             indexer.append(&block).expect("append block should be OK");
                         } else {
-                            info!("rollback {}, {}", tip_number, tip_hash);
-                            indexer.rollback().expect("rollback block should be OK");
+                            // Long fork detection
+                            let longest_fork_number = tip_number.saturating_sub(keep_num);
+                            match get_block_by_number(
+                                &rpc_client,
+                                longest_fork_number,
+                                use_hex_format,
+                            )
+                            .await
+                            {
+                                Ok(Some(block)) => {
+                                    let stored_block_hash = indexer
+                                        .get_block_hash(longest_fork_number)
+                                        .expect("get block hash should be OK")
+                                        .expect("stored block header");
+                                    if block.hash() != stored_block_hash {
+                                        error!("long fork detected, ckb-indexer stored block {} => {:#x}, ckb node returns block {} => {:#x}, please check if ckb-indexer is connected to the same network ckb node.", longest_fork_number, stored_block_hash, longest_fork_number, block.hash());
+                                        thread::sleep(self.poll_interval);
+                                    } else {
+                                        info!("rollback {}, {}", tip_number, tip_hash);
+                                        indexer.rollback().expect("rollback block should be OK");
+                                    }
+                                }
+                                Ok(None) => {
+                                    error!("long fork detected, ckb-indexer stored block {}, ckb node returns none, please check if ckb-indexer is connected to the same network ckb node.", longest_fork_number);
+                                    thread::sleep(self.poll_interval);
+                                }
+                                Err(err) => {
+                                    error!("cannot get block from ckb node, error: {}", err);
+                                    thread::sleep(self.poll_interval);
+                                }
+                            }
                         }
                     }
                     Ok(None) => {


### PR DESCRIPTION
Avoid incorrect block rollbacks, especially in development environments when the ckb-indexer is connected to a different network of ckb node.