### PR TITLE
feat: index the pending txs in the ckb tx-pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,14 @@ Connect to default ckb rpc service at `http://127.0.0.1:8114` and stores the ind
 RUST_LOG=info ./target/release/ckb-indexer -s /tmp/ckb-indexer-test
 ```
 
-Or connect to ckb rpc service at `tcp::/127.0.0.1:18114`
+Or connect to ckb rpc service at `tcp://127.0.0.1:18114`
 ```bash
-RUST_LOG=info ./target/release/ckb-indexer -s /tmp/ckb-indexer-test -c tcp::/127.0.0.1:18114
+RUST_LOG=info ./target/release/ckb-indexer -s /tmp/ckb-indexer-test -c tcp://127.0.0.1:18114
+```
+
+Indexing the pending txs in the ckb tx-pool
+```bash
+RUST_LOG=info ./target/release/ckb-indexer -s /tmp/ckb-indexer-test -c tcp://127.0.0.1:18114 --index-tx-pool
 ```
 
 Run `ckb-indexer --help` for more information

--- a/README.md
+++ b/README.md
@@ -4,10 +4,23 @@ All the [indexing](https://github.com/nervosnetwork/ckb/tree/develop/rpc#indexer
 
 ## Usage
 
+Build binary from source
+
 ```bash
 cargo build --release
+```
+
+Connect to default ckb rpc service at `http://127.0.0.1:8114` and stores the indexer data at `/tmp/ckb-indexer-test` folder
+```bash
 RUST_LOG=info ./target/release/ckb-indexer -s /tmp/ckb-indexer-test
 ```
+
+Or connect to ckb rpc service at `tcp::/127.0.0.1:18114`
+```bash
+RUST_LOG=info ./target/release/ckb-indexer -s /tmp/ckb-indexer-test -c tcp::/127.0.0.1:18114
+```
+
+Run `ckb-indexer --help` for more information
 
 ## RPC
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod indexer;
+pub mod pool;
 pub mod service;
 pub mod store;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,12 @@
 use ckb_indexer::service::Service;
 use clap::{crate_version, App, Arg};
-use jsonrpc_core_client::transports::http;
+use futures::{SinkExt, StreamExt, TryStreamExt};
+use jsonrpc_core_client::transports::{duplex::duplex, http};
+use jsonrpc_server_utils::{
+    codecs::StreamCodec,
+    tokio::{self, net::TcpStream},
+    tokio_util::codec::Decoder,
+};
 
 #[tokio::main]
 async fn main() {
@@ -12,7 +18,7 @@ async fn main() {
         .arg(
             Arg::with_name("ckb_uri")
                 .short("c")
-                .help("CKB rpc http service uri, default http://127.0.0.1:8114")
+                .help("CKB rpc service uri, supports http and tcp, for example: `http://127.0.0.1:8114` or `tcp::/127.0.0.1:18114`")
                 .takes_value(true),
         )
         .arg(
@@ -42,15 +48,34 @@ async fn main() {
         .value_of("ckb_uri")
         .unwrap_or("http://127.0.0.1:8114")
         .to_owned();
-    if !uri.starts_with("http") {
+
+    if uri.starts_with("tcp:://") {
+        let uri = uri.split_off(7);
+        let codec = StreamCodec::stream_incoming();
+        let tcp_stream = TcpStream::connect(&uri)
+            .await
+            .expect(&format!("Failed to connect to {:?}", uri));
+        let (sink, stream) = codec.framed(tcp_stream).split();
+        let sink = sink.sink_map_err(|e| panic!("split sink error: {:?}", e));
+        let stream = stream.map_err(|e| panic!("split stream error: {:?}", e));
+
+        let (duplex, rpc_channel) = duplex(
+            Box::pin(sink),
+            Box::pin(
+                stream
+                    .take_while(|x| futures::future::ready(x.is_ok()))
+                    .map(|x| x.expect("stream is closed on errors")),
+            ),
+        );
+        tokio::spawn(duplex);
+        service.poll(rpc_channel.into()).await;
+    } else if !uri.starts_with("http") {
         uri = format!("http://{}", uri);
+        let client = http::connect(&uri)
+            .await
+            .expect(&format!("Failed to connect to {:?}", uri));
+        service.poll(client).await;
     }
-
-    let client = http::connect(&uri)
-        .await
-        .expect(&format!("Failed to connect to {:?}", uri));
-
-    service.poll(client).await;
 
     rpc_server.close();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,19 @@
-use ckb_indexer::service::Service;
+use ckb_indexer::{pool::Pool, service::Service};
+use ckb_jsonrpc_types::{PoolTransactionEntry, PoolTransactionReject};
+use ckb_types::packed::Transaction;
 use clap::{crate_version, App, Arg};
 use futures::{SinkExt, StreamExt, TryStreamExt};
-use jsonrpc_core_client::transports::{duplex::duplex, http};
+use jsonrpc_core_client::{
+    transports::{duplex::duplex, http},
+    TypedClient,
+};
 use jsonrpc_server_utils::{
     codecs::StreamCodec,
     tokio::{self, net::TcpStream},
     tokio_util::codec::Decoder,
 };
+use log::{debug, error};
+use std::sync::{Arc, RwLock};
 
 #[tokio::main]
 async fn main() {
@@ -34,10 +41,23 @@ async fn main() {
                 .required(true)
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("index_tx_pool")
+                .long("index-tx-pool")
+                .help("Whether to index the pending txs in the ckb tx-pool")
+                .required(false)
+        )
         .get_matches();
 
+    let index_tx_pool = matches.is_present("index_tx_pool");
+    let pool = Arc::new(RwLock::new(Pool::new()));
     let service = Service::new(
         matches.value_of("store_path").expect("required arg"),
+        if index_tx_pool {
+            Some(pool.clone())
+        } else {
+            None
+        },
         matches.value_of("listen_uri").unwrap_or("127.0.0.1:8116"),
         std::time::Duration::from_secs(2),
         crate_version!().to_string(),
@@ -56,8 +76,8 @@ async fn main() {
             .await
             .expect(&format!("Failed to connect to {:?}", uri));
         let (sink, stream) = codec.framed(tcp_stream).split();
-        let sink = sink.sink_map_err(|e| panic!("split sink error: {:?}", e));
-        let stream = stream.map_err(|e| panic!("split stream error: {:?}", e));
+        let sink = sink.sink_map_err(|e| error!("tcp sink error: {:?}", e));
+        let stream = stream.map_err(|e| error!("tcp stream error: {:?}", e));
 
         let (duplex, rpc_channel) = duplex(
             Box::pin(sink),
@@ -68,13 +88,117 @@ async fn main() {
             ),
         );
         tokio::spawn(duplex);
+
+        if index_tx_pool {
+            // subscribe `new_transaction` topic
+            {
+                let typed_client: TypedClient = rpc_channel.clone().into();
+                let pool = pool.clone();
+                let fut = async move {
+                    match typed_client.subscribe::<_, String>(
+                        "subscribe",
+                        ["new_transaction"],
+                        "subscribe",
+                        "unsubscribe",
+                        "String",
+                    ) {
+                        Ok(mut stream) => loop {
+                            if let Some(subscription) = stream.next().await {
+                                match subscription {
+                                    Ok(json_string) => {
+                                        debug!(
+                                            "Rpc subscription notified a new transaction: {}",
+                                            json_string
+                                        );
+                                        if let Ok(pool_tx_entry) =
+                                            serde_json::from_str::<PoolTransactionEntry>(
+                                                &json_string,
+                                            )
+                                        {
+                                            let tx: Transaction =
+                                                pool_tx_entry.transaction.inner.into();
+                                            pool.write()
+                                                .expect("acquire lock")
+                                                .new_transaction(&tx.into_view());
+                                        } else {
+                                            error!("Failed to parse json_string: {}", json_string);
+                                        }
+                                    }
+                                    Err(err) => {
+                                        error!("Rpc subscription error {:?}", err);
+                                    }
+                                }
+                            }
+                        },
+                        Err(err) => {
+                            error!("subscribe error {:?}", err);
+                        }
+                    }
+                };
+                tokio::spawn(fut);
+            }
+
+            // subscribe `rejected_transaction` topic
+            {
+                let typed_client: TypedClient = rpc_channel.clone().into();
+                let pool = pool.clone();
+                let fut = async move {
+                    match typed_client.subscribe::<_, String>(
+                        "subscribe",
+                        ["rejected_transaction"],
+                        "subscribe",
+                        "unsubscribe",
+                        "String",
+                    ) {
+                        Ok(mut stream) => loop {
+                            if let Some(subscription) = stream.next().await {
+                                match subscription {
+                                    Ok(json_string) => {
+                                        debug!(
+                                            "Rpc subscription notified a rejected transaction: {}",
+                                            json_string
+                                        );
+                                        if let Ok((pool_tx_entry, _)) = serde_json::from_str::<(
+                                            PoolTransactionEntry,
+                                            PoolTransactionReject,
+                                        )>(
+                                            &json_string
+                                        ) {
+                                            let tx: Transaction =
+                                                pool_tx_entry.transaction.inner.into();
+                                            pool.write()
+                                                .expect("acquire lock")
+                                                .transaction_rejected(&tx.into_view());
+                                        } else {
+                                            error!("Failed to parse json_string: {}", json_string);
+                                        }
+                                    }
+                                    Err(err) => {
+                                        error!("Rpc subscription error {:?}", err);
+                                    }
+                                }
+                            }
+                        },
+                        Err(err) => {
+                            error!("subscribe error {:?}", err);
+                        }
+                    }
+                };
+                tokio::spawn(fut);
+            }
+        }
+
         service.poll(rpc_channel.into()).await;
     } else if !uri.starts_with("http") {
-        uri = format!("http://{}", uri);
-        let client = http::connect(&uri)
-            .await
-            .expect(&format!("Failed to connect to {:?}", uri));
-        service.poll(client).await;
+        if index_tx_pool {
+            error!("indexing the pending txs in the ckb tx-pool is only supported when connecting to ckb rpc service with tcp protocol")
+        } else {
+            uri = format!("http://{}", uri);
+            let client = http::connect(&uri)
+                .await
+                .expect(&format!("Failed to connect to {:?}", uri));
+            service.poll(client).await;
+        }
     }
 
     rpc_server.close();

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ async fn main() {
         .arg(
             Arg::with_name("ckb_uri")
                 .short("c")
-                .help("CKB rpc service uri, supports http and tcp, for example: `http://127.0.0.1:8114` or `tcp::/127.0.0.1:18114`")
+                .help("CKB rpc service uri, supports http and tcp, for example: `http://127.0.0.1:8114` or `tcp://127.0.0.1:18114`")
                 .takes_value(true),
         )
         .arg(
@@ -69,8 +69,8 @@ async fn main() {
         .unwrap_or("http://127.0.0.1:8114")
         .to_owned();
 
-    if uri.starts_with("tcp:://") {
-        let uri = uri.split_off(7);
+    if uri.starts_with("tcp://") {
+        let uri = uri.split_off(6);
         let codec = StreamCodec::stream_incoming();
         let tcp_stream = TcpStream::connect(&uri)
             .await
@@ -189,11 +189,10 @@ async fn main() {
         }
 
         service.poll(rpc_channel.into()).await;
-    } else if !uri.starts_with("http") {
+    } else {
         if index_tx_pool {
             error!("indexing the pending txs in the ckb tx-pool is only supported when connecting to ckb rpc service with tcp protocol")
         } else {
-            uri = format!("http://{}", uri);
             let client = http::connect(&uri)
                 .await
                 .expect(&format!("Failed to connect to {:?}", uri));

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,0 +1,47 @@
+use ckb_types::{core::TransactionView, packed::OutPoint};
+use std::collections::HashSet;
+
+/// an overlay to index the pending txs in the ckb tx pool,
+/// currently only supports removals of dead cells from the pending txs
+pub struct Pool {
+    dead_cells: HashSet<OutPoint>,
+}
+
+impl Pool {
+    pub fn new() -> Self {
+        Self {
+            dead_cells: HashSet::new(),
+        }
+    }
+
+    // the tx has been comitted in a block, it should be removed from pending dead cells
+    pub fn transaction_commited(&mut self, tx: &TransactionView) {
+        for input in tx.inputs() {
+            self.dead_cells.remove(&input.previous_output());
+        }
+    }
+
+    // the tx has been rejected for some reason, it should be removed from pending dead cells
+    pub fn transaction_rejected(&mut self, tx: &TransactionView) {
+        for input in tx.inputs() {
+            self.dead_cells.remove(&input.previous_output());
+        }
+    }
+
+    // a new tx is submitted to the pool, mark its inputs as dead cells
+    pub fn new_transaction(&mut self, tx: &TransactionView) {
+        for input in tx.inputs() {
+            self.dead_cells.insert(input.previous_output());
+        }
+    }
+
+    pub fn is_consumed_by_pool_tx(&self, out_point: &OutPoint) -> bool {
+        self.dead_cells.contains(out_point)
+    }
+
+    pub fn transactions_commited(&mut self, txs: &[TransactionView]) {
+        for tx in txs {
+            self.transaction_commited(tx);
+        }
+    }
+}


### PR DESCRIPTION
This PR added an overlay to index the pending txs in the ckb-tx pool, when rpc `get_cells` and `get_cells_capacity` are called, the live cells which are consumed by pending txs in the ckb-tx pool will be excluded.

## How to use
```
ckb-indexer -s ~/ckb-test/ckb-indexer-test -c tcp://127.0.0.1:18114 --index-tx-pool
```