### PR TITLE
feat: filter by empty type script

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,38 @@ echo '{
 http://localhost:8116
 ```
 
+get cells by lock script and filter by empty type script
+
+```bash
+echo '{
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "get_cells",
+    "params": [
+        {
+            "script": {
+                "code_hash": "0x86a1c6987a4acbe1a887cca4c9dd2ac9fcb07405bbeda51b861b18bbf7492c4b",
+                "hash_type": "type",
+                "args": "0xb728659574c85e88d957bd643bb747a00f018d72"
+            },
+            "script_type": "lock",
+            "filter": {
+                "script": {
+                    "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "hash_type": "data",
+                    "args": "0x"
+                }
+            }
+        },
+        "asc",
+        "0x64"
+    ]
+}' \
+| tr -d '\n' \
+| curl -H 'content-type: application/json' -d @- \
+http://localhost:8116
+```
+
 get cells by lock script and filter capacity range
 
 ```bash

--- a/src/service.rs
+++ b/src/service.rs
@@ -1062,6 +1062,48 @@ mod tests {
             "total size should be filtered cellbase cells (100~199)"
         );
 
+        let filter_empty_type_script_cells_page_1 = rpc
+            .get_cells(
+                SearchKey {
+                    script: lock_script1.clone().into(),
+                    script_type: ScriptType::Lock,
+                    filter: Some(SearchKeyFilter {
+                        script: Some(ScriptBuilder::default().build().into()),
+                        output_data_len_range: None,
+                        output_capacity_range: None,
+                        block_range: None,
+                    }),
+                },
+                Order::Asc,
+                150.into(),
+                None,
+            )
+            .unwrap();
+
+        let filter_empty_type_script_cells_page_1 = rpc
+            .get_cells(
+                SearchKey {
+                    script: lock_script1.clone().into(),
+                    script_type: ScriptType::Lock,
+                    filter: Some(SearchKeyFilter {
+                        script: Some(ScriptBuilder::default().build().into()),
+                        output_data_len_range: None,
+                        output_capacity_range: None,
+                        block_range: None,
+                    }),
+                },
+                Order::Asc,
+                150.into(),
+                Some(filter_empty_type_script_cells_page_1.last_cursor),
+            )
+            .unwrap();
+
+        assert_eq!(
+            total_blocks as usize,
+            filter_empty_type_script_cells_page_1.objects.len() + filter_empty_type_script_cells_page_1.objects.len(),
+            "total size should be cellbase cells count (no type script)"
+        );
+
         // test get_transactions rpc
         let txs_page_1 = rpc
             .get_transactions(


### PR DESCRIPTION
resolve https://github.com/nervosnetwork/ckb-indexer/issues/47

this PR allows user to filter empty type script cells:
```bash
echo '{
    "id": 2,
    "jsonrpc": "2.0",
    "method": "get_cells",
    "params": [
        {
            "script": {
                "code_hash": "0x86a1c6987a4acbe1a887cca4c9dd2ac9fcb07405bbeda51b861b18bbf7492c4b",
                "hash_type": "type",
                "args": "0xb728659574c85e88d957bd643bb747a00f018d72"
            },
            "script_type": "lock",
            "filter": {
                "script": {
                    "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
                    "hash_type": "data",
                    "args": "0x"
                }
            }
        },
        "asc",
        "0x64"
    ]
}' \
| tr -d '\n' \
| curl -H 'content-type: application/json' -d @- \
http://localhost:8116
```