### PR TITLE
feat: add exact search mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Returns the live cells collection by the lock or type script.
     search_key:
         script - Script, supports prefix search
         scrip_type - enum, lock | type
+        script_search_mode - enum, prefix | exact, optional default is `prefix`, controls the search mode of script
         filter - filter cells by following conditions, all conditions are optional
             script: if search script type is lock, filter cells by type script prefix, and vice versa
             script_len_range: [u64; 2], filter cells by script len range, [inclusive, exclusive]
@@ -461,6 +462,7 @@ Returns the transactions collection by the lock or type script.
     search_key:
         script - Script, supports prefix search when group_by_transaction is false
         scrip_type - enum, lock | type
+        script_search_mode - enum, prefix | exact, optional default is `prefix`, controls the search mode of script
         filter - filter cells by following conditions, all conditions are optional
             script: if search script type is lock, filter cells by type script, and vice versa
             block_range: [u64; 2], filter cells by block number range, [inclusive, exclusive]
@@ -883,6 +885,7 @@ Returns the live cells capacity by the lock or type script.
     search_key:
         script - Script
         scrip_type - enum, lock | type
+        script_search_mode - enum, prefix | exact, optional default is `prefix`, controls the search mode of script
         filter - filter cells by following conditions, all conditions are optional
             script: if search script type is lock, filter cells by type script prefix, and vice versa
             output_data_len_range: [u64; 2], filter cells by output data len range, [inclusive, exclusive]


### PR DESCRIPTION
Developer may need to match the exact script for the query in some cases, currently the rpc only has prefix matching, the developer can only get the cells and then filter them on the client side, this PR adds the exact match mode.